### PR TITLE
Installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,24 @@
 PHPStan Extension - Magento 2 Magic Methods
 ===================
 
-### Installation Instructions via Composer
+### Installation
 
-    composer require --dev fooman/phpstan-magento2-magic-methods
- 
+To use this extension, require it in [Composer](https://getcomposer.org/):
+
+```
+composer require --dev fooman/phpstan-magento2-magic-methods
+```
+
+If you also install [phpstan/extension-installer](https://github.com/phpstan/extension-installer) then you're all set!
+
+<details>
+  <summary>Manual installation</summary>
+
+If you don't want to use `phpstan/extension-installer`, include extension.neon in your project's PHPStan config:
+
+```
+includes:
+    - vendor/fooman/phpstan-magento2-magic-methods/extension.neon
+```
+
+</details>


### PR DESCRIPTION
Hi,
phpstan/extension-installer is completely optional. Your README should still contain instructions on how to get going.

As for your question:

> Question is there a way for an extension to plug into broker->hasClass() for dynamically created classes?

What is "dynamically created class"?