### PR TITLE
Update extension.neon

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
     },
     "require": {
         "php": "^7.1",
-        "phpstan/phpstan": ">=0.12.0",
+        "phpstan/phpstan": ">=0.12.26",
         "phpstan/extension-installer": "^1.0",
         "magento/framework": "^100.0 | ^101.0.0 | ^102.0.0 | ^103.0.0"
     },

--- a/extension.neon
+++ b/extension.neon
@@ -4,5 +4,5 @@ services:
     tags:
         - phpstan.broker.methodsClassReflectionExtension
 parameters:
-    autoload_files:
+    bootstrapFiles:
         - %rootDir%/../../fooman/phpstan-magento2-magic-methods/bootstrap.php


### PR DESCRIPTION
Fix phpstan.neon to work with latest phpstan

```
⚠️  You're using a deprecated config option autoload_files. ⚠️️
You might not need it anymore - try removing it from your
configuration file and run PHPStan again.
If the analysis fails, there are now two distinct options
to choose from to replace autoload_files:
1) scanFiles - PHPStan will scan those for classes and functions
   definitions. PHPStan will not execute those files.
2) bootstrapFiles - PHPStan will execute these files to prepare
   the PHP runtime environment for the analysis.
Read more about this in PHPStan's documentation:
https://phpstan.org/user-guide/discovering-symbols
```